### PR TITLE
Update javascript library to use faster loading one.

### DIFF
--- a/intercom/templates/intercom/intercom_tag.html
+++ b/intercom/templates/intercom/intercom_tag.html
@@ -20,7 +20,7 @@
         function async_load() {
           var s = document.createElement('script');
           s.type = 'text/javascript'; s.async = true;
-          s.src = 'https://api.intercom.io/api/js/library.js';
+          s.src = 'https://static.intercomcdn.com/intercom.v1.js';
           var x = document.getElementsByTagName('script')[0];
           x.parentNode.insertBefore(s, x);
         }


### PR DESCRIPTION
From the intercom website:

Faster loading Intercom javascript

We now serve the Intercom javascript from a CDN. This means faster load times for your users, no matter where in the world they live.
To take advantage, change your script tag from using https://api.intercom.io/api/js/library.js tohttps://static.intercomcdn.com/intercom.v1.js
The old one will continue to work, so don't worry if you can't make this change immediately.
If you're using our intercom-rails gem, then the latest version will do this for you.
