### PR TITLE
Added check for case where request object is not present in context

### DIFF
--- a/intercom/templatetags/intercom.py
+++ b/intercom/templatetags/intercom.py
@@ -36,6 +36,11 @@ def intercom_tag(context):
         little cleaner then doing everything in the template.
     """
 
+    # Ensure that the context contains a value for the request key before
+    # continuing.
+    if not context.has_key('request'):
+        return {"INTERCOM_IS_VALID" : False}
+
     request = context['request']
 
     if INTERCOM_APPID is None:


### PR DESCRIPTION
Hello,

The intercom template tag assumes that the context will always contain a request object; when an exception is raised in a view this causes the template tag to raise a KeyError which then masks the actual error upstream.

I've added a check to ensure that there is a value for the request key, otherwise False is returned immediately.
