### PR TITLE
Fix setup.py problems on Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:
 
 
 def read(fname):
-    return codecs.open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return codecs.open(os.path.join(os.path.dirname(__file__), fname), 'rb', 'utf-8').read()
 
 
 def get_packages(package):


### PR DESCRIPTION
On one of my servers the install failed:

```
Collecting django-intercom
  Downloading django-intercom-0.0.12.tar.gz
    Complete output from command python setup.py egg_info:
    
    Installed /tmp/pip-build-scva4_4g/django-intercom/.eggs/versiontools-1.9.1-py3.4.egg
    running egg_info
    creating pip-egg-info/django_intercom.egg-info
    writing pip-egg-info/django_intercom.egg-info/PKG-INFO
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-scva4_4g/django-intercom/setup.py", line 63, in <module>
        'versiontools >= 1.8.2',
      File "/usr/lib/python3.4/distutils/core.py", line 148, in setup
        dist.run_commands()
      File "/usr/lib/python3.4/distutils/dist.py", line 955, in run_commands
        self.run_command(cmd)
      File "/usr/lib/python3.4/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/var/venv/radar/lib/python3.4/site-packages/setuptools/command/egg_info.py", line 179, in run
        writer(self, ep.name, os.path.join(self.egg_info, ep.name))
      File "/var/venv/radar/lib/python3.4/site-packages/setuptools/command/egg_info.py", line 390, in write_pkg_info
        metadata.write_pkg_info(cmd.egg_info)
      File "/usr/lib/python3.4/distutils/dist.py", line 1108, in write_pkg_info
        self.write_pkg_file(pkg_info)
      File "/usr/lib/python3.4/distutils/dist.py", line 1129, in write_pkg_file
        long_desc = rfc822_escape(self.get_long_description())
      File "/usr/lib/python3.4/distutils/util.py", line 470, in rfc822_escape
        lines = header.split('\n')
    TypeError: Type str doesn't support the buffer API
```

I found a fix here: https://github.com/pinax/pinax-eventlog/commit/fe4bff1f5fcf31ea27cf1a69e98db675124b7921

To verify, this failed:

    pip install -e git+https://github.com/kencochrane/django-intercom#egg=django-intercom

While installing this branch worked:

    pip install -e git+https://github.com/wbrp/django-intercom@fix-setup#egg=django-intercom

Could you do a patch release with this? :)