### PR TITLE
Fixed a bug that was failing to encode the hmac value for secure mode.

### DIFF
--- a/intercom/templatetags/intercom.py
+++ b/intercom/templatetags/intercom.py
@@ -127,7 +127,7 @@ def intercom_tag(context):
 
         # this is optional, if they don't have the setting set, it won't use.
         if INTERCOM_SECURE_KEY is not None:
-            hmac_value = user_id if user_id else email
+            hmac_value = str(user_id) if user_id else email
             user_hash = hmac.new(INTERCOM_SECURE_KEY.encode('utf8'),
                                  hmac_value.encode('utf8'),
                                  digestmod=hashlib.sha256).hexdigest()


### PR DESCRIPTION
I hit an error like this while trying to use Intercom's secure mode with this module:
```
[...]
  File "/home/bwood/priceonomics/env/lib/python2.7/site-packages/intercom/templatetags/intercom.py", line 132, in intercom_tag
    hmac_value.encode('utf8'),
AttributeError: 'int' object has no attribute 'encode'
```
Looks like it was just trying to encode an int (user id) instead of the string representation of that int.