### PR TITLE
Fix intercom_tag when user is not authenticated

### DIFF
--- a/django_intercom/templatetags/intercom.py
+++ b/django_intercom/templatetags/intercom.py
@@ -74,7 +74,7 @@ def intercom_tag(context):
         log.warning("INTERCOM_APPID isn't setup correctly in your settings")
 
     # make sure INTERCOM_APPID is setup correct and user is authenticated
-    if INTERCOM_APPID and request.user and request.user.is_authenticated:
+    if INTERCOM_APPID and request.user and request.user.is_authenticated():
         user_data = {}
         if INTERCOM_USER_DATA_CLASS:
             try:


### PR DESCRIPTION
Comparison was done with the function definition instead of the function call.
The test was true whenever INTERCOM_APPID was set and this raised an error "'AnonymousUser' object has no attribute 'email'" when reaching the following line:
`email = user_data.get('email', request.user.email)`